### PR TITLE
fix: changed plot_fui.py to use the correct fui:NamedList functions

### DIFF
--- a/fast_fmm_rpy2/plot_fui.py
+++ b/fast_fmm_rpy2/plot_fui.py
@@ -112,7 +112,10 @@ def plot_fui(
         # Create plotting dataframe
         if "betaHat.var" not in fuiobj.names():
             beta_hat_plt = pd.DataFrame(
-                {"s": fuiobj.getbyname("argvals"), "beta": fuiobj.getbyname("betaHat").iloc[r, :]}
+                {
+                    "s": fuiobj.getbyname("argvals"),
+                    "beta": fuiobj.getbyname("betaHat").iloc[r, :],
+                }
             )
 
             # Plot estimate
@@ -183,7 +186,10 @@ def plot_fui(
         if ylim is not None:
             ax.set_ylim(ylim)
         else:
-            if "betaHat.var" not in fuiobj.names() or fuiobj.getbyname("betaHat.var") is None:
+            if (
+                "betaHat.var" not in fuiobj.names()
+                or fuiobj.getbyname("betaHat.var") is None
+            ):
                 y_range = [
                     beta_hat_plt["beta"].min(),
                     beta_hat_plt["beta"].max(),

--- a/fast_fmm_rpy2/plot_fui.py
+++ b/fast_fmm_rpy2/plot_fui.py
@@ -32,8 +32,10 @@ def plot_fui(
 
     Parameters:
     -----------
-    fuiobj : dict
-        A dictionary containing the following keys:
+    fuiobj : rpy2.rlike.container.NamedList
+        Functional univariate inference object returned from fastFMM.fui.
+
+        Contains the following names:
         - betaHat: numpy array of shape (num_vars, num_points) containing
             coefficient estimates
         - betaHat_var: numpy array of shape (num_points, num_points, num_vars)
@@ -67,8 +69,8 @@ def plot_fui(
         If return_data=True, returns (figure, list of dataframes)
     """
     # number of variables to plot
-    num_var = fuiobj["betaHat"].shape[0]
-    var_names = fuiobj["betaHat"].index.to_list()
+    num_var = fuiobj.getbyname("betaHat").shape[0]
+    var_names = fuiobj.getbyname("betaHat").index.to_list()
     res_list = []
     if num_row is None:
         num_row = int(np.ceil(num_var / 2))
@@ -78,18 +80,18 @@ def plot_fui(
 
     if title_names is None:
         try:
-            title_names = fuiobj["betaHat"].index.to_list()
+            title_names = fuiobj.getbyname("betaHat").index.to_list()
         except KeyError:
             title_names = [f"Variable {i}" for i in range(num_var)]
 
     # sanity check the number of rows with number of varibles
-    if not len(fuiobj["betaHat"]) == len(title_names):
+    if not len(fuiobj.getbyname("betaHat")) == len(title_names):
         Warning(
             "Incorrect number of title_names detected,"
             + " replacing title names in plots"
         )
         try:
-            title_names = fuiobj["betaHat"].index.to_list()
+            title_names = fuiobj.getbyname("betaHat").index.to_list()
         except KeyError:
             title_names = [f"Variable {i}" for i in range(num_var)]
 
@@ -108,9 +110,9 @@ def plot_fui(
         ax = fig.add_subplot(gs[row, col])
 
         # Create plotting dataframe
-        if "betaHat.var" not in fuiobj:
+        if "betaHat.var" not in fuiobj.names():
             beta_hat_plt = pd.DataFrame(
-                {"s": fuiobj["argvals"], "beta": fuiobj["betaHat"].iloc[r, :]}
+                {"s": fuiobj.getbyname("argvals"), "beta": fuiobj.getbyname("betaHat").iloc[r, :]}
             )
 
             # Plot estimate
@@ -125,19 +127,19 @@ def plot_fui(
             )
 
         else:
-            var_diag = np.diag(fuiobj["betaHat.var"][:, :, r])
+            var_diag = np.diag(fuiobj.getbyname("betaHat.var")[:, :, r])
             beta_hat_plt = pd.DataFrame(
                 {
-                    "s": fuiobj["argvals"],
-                    "beta": fuiobj["betaHat"].iloc[r, :],
-                    "lower": fuiobj["betaHat"].iloc[r, :]
+                    "s": fuiobj.getbyname("argvals"),
+                    "beta": fuiobj.getbyname("betaHat").iloc[r, :],
+                    "lower": fuiobj.getbyname("betaHat").iloc[r, :]
                     - 2 * np.sqrt(var_diag),
-                    "upper": fuiobj["betaHat"].iloc[r, :]
+                    "upper": fuiobj.getbyname("betaHat").iloc[r, :]
                     + 2 * np.sqrt(var_diag),
-                    "lower_joint": fuiobj["betaHat"].iloc[r, :]
-                    - fuiobj["qn"][r] * np.sqrt(var_diag),
-                    "upper_joint": fuiobj["betaHat"].iloc[r, :]
-                    + fuiobj["qn"][r] * np.sqrt(var_diag),
+                    "lower_joint": fuiobj.getbyname("betaHat").iloc[r, :]
+                    - fuiobj.getbyname("qn")[r] * np.sqrt(var_diag),
+                    "upper_joint": fuiobj.getbyname("betaHat").iloc[r, :]
+                    + fuiobj.getbyname("qn")[r] * np.sqrt(var_diag),
                 }
             )
 
@@ -181,7 +183,7 @@ def plot_fui(
         if ylim is not None:
             ax.set_ylim(ylim)
         else:
-            if "betaHat.var" not in fuiobj or fuiobj["betaHat.var"] is None:
+            if "betaHat.var" not in fuiobj.names() or fuiobj.getbyname("betaHat.var") is None:
                 y_range = [
                     beta_hat_plt["beta"].min(),
                     beta_hat_plt["beta"].max(),

--- a/fast_fmm_rpy2/plot_fui.py
+++ b/fast_fmm_rpy2/plot_fui.py
@@ -7,7 +7,7 @@ import rpy2.rinterface as rinterface  # type: ignore
 from matplotlib.gridspec import GridSpec
 from rpy2 import robjects as ro  # type: ignore
 from rpy2.rinterface_lib.sexp import NULLType  # type: ignore
-from rpy2.rlike.container import OrdDict  # type: ignore
+from rpy2.rlike.container import NamedList  # type: ignore
 from rpy2.robjects import pandas2ri  # type: ignore
 from rpy2.robjects.conversion import localconverter  # type: ignore
 from rpy2.robjects.packages import importr  # type: ignore
@@ -229,14 +229,14 @@ def r_export_plot_fui_results(
     ro.r("mod <- fui(photometry ~ cs + (1 | id), data = dat, parallel = TRUE)")
     ro.r("plot_data <- plot_fui(mod, return=TRUE)")
     with (ro.default_converter + pandas2ri.converter).context():
-        intercept_dict: OrdDict = ro.conversion.get_conversion().rpy2py(
+        intercept_list: NamedList = ro.conversion.get_conversion().rpy2py(
             ro.r("plot_data['(Intercept)']")
         )
-        r_intercept: pd.DataFrame = intercept_dict["(Intercept)"]
-        cs_dict: OrdDict = ro.conversion.get_conversion().rpy2py(
+        r_intercept: pd.DataFrame = intercept_list.getbyname("(Intercept)")
+        cs_list: NamedList = ro.conversion.get_conversion().rpy2py(
             ro.r("plot_data['cs']")
         )
-        r_cs: pd.DataFrame = cs_dict["cs"]
+        r_cs: pd.DataFrame = cs_list.getbyname("cs")
     return r_intercept, r_cs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = [
 ]
 
 dependencies = [
-    "rpy2",
+    "rpy2>=3.6",
     "pandas",
     "matplotlib",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fast-fmm-rpy2"
-version = "1.0.2"
+version = "1.0.3"
 description = "FLMM rpy2 wrapper for analyzing Fiber Photometry data"
 authors = [
     {name = "Josh Lawrimore", email = "josh.lawrimore@gmail.com"},
@@ -72,7 +72,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.bumpversion]
-current_version = "1.0.2"
+current_version = "1.0.3"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/tests/test_fmm.py
+++ b/tests/test_fmm.py
@@ -35,39 +35,43 @@ def rpy2py_floatvector(obj):
 
 
 def compare_models(mod, r_mod) -> None:
-    for key in dict(mod).keys():
-        if isinstance(mod[key], ndarray):
+    for key in mod.names():
+        if isinstance(mod.getbyname(key), ndarray):
             # check for nans
-            mod_data_is_nan = np.isnan(mod[key])
+            mod_data_is_nan = np.isnan(mod.getbyname(key))
             mod_nan_cols = np.any(mod_data_is_nan, axis=0)
             if np.any(mod_nan_cols):
-                mod_data = mod[key][:, ~mod_nan_cols]
-                r_mod_data = r_mod[key][:, ~mod_nan_cols]
+                mod_data = mod.getbyname(key)[:, ~mod_nan_cols]
+                r_mod_data = r_mod.getbyname(key)[:, ~mod_nan_cols]
             else:
-                mod_data = mod[key]
-                r_mod_data = r_mod[key]
+                mod_data = mod.getbyname(key)
+                r_mod_data = r_mod.getbyname(key)
             mod_flat = mod_data.flatten()
             r_mod_flat = r_mod_data.flatten()
-        elif isinstance(mod[key], DataFrame):
-            mod_flat = mod[key].to_numpy().flatten()
-            r_mod_flat = r_mod[key].to_numpy().flatten()
-        elif isinstance(mod[key], BoolVector):
-            mod_flat = np.array(mod[key]).flatten()
-            r_mod_flat = np.array(mod[key]).flatten()
-        elif isinstance(mod[key], NULLType):
-            assert isinstance(mod[key], NULLType) == isinstance(
-                r_mod[key], NULLType
+        elif isinstance(mod.getbyname(key), DataFrame):
+            mod_flat = mod.getbyname(key).to_numpy().flatten()
+            r_mod_flat = r_mod.getbyname(key).to_numpy().flatten()
+        elif isinstance(mod.getbyname(key), BoolVector):
+            mod_flat = np.array(mod.getbyname(key)).flatten()
+            r_mod_flat = np.array(mod.getbyname(key)).flatten()
+        elif isinstance(mod.getbyname(key), NULLType):
+            assert isinstance(mod.getbyname(key), NULLType) == isinstance(
+                r_mod.getbyname(key), NULLType
             ), f"{key} is NULLType for mod but not r_mod!"
             continue
         else:
-            raise ValueError(f"{key} is a {type(mod[key])} variable!")
+            raise ValueError(
+                f"{key} is a {type(mod.getbyname(key))} variable!"
+            )
         try:
             assert np.allclose(mod_flat, r_mod_flat), (
                 "R dataframe vs Pandas DataFrame resulted"
                 + f" in different models for {key}"
             )
         except ValueError:
-            raise ValueError(f"{key} is a {type(mod[key])} variable!")
+            raise ValueError(
+                f"{key} is a {type(mod.getbyname(key))} variable!"
+            )
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -131,7 +130,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -256,10 +255,9 @@ requires-dist = [
     { name = "pandas" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
-    { name = "rpy2" },
+    { name = "rpy2", specifier = ">=3.6" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "fonttools"
@@ -1072,15 +1070,52 @@ wheels = [
 
 [[package]]
 name = "rpy2"
-version = "3.5.17"
+version = "3.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging", marker = "platform_system == 'Windows'" },
+    { name = "rpy2-rinterface" },
+    { name = "rpy2-robjects" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/ba/393d5aaf21204d7678e59f7e7cd54d9a929d5f7ad8218f172100c8c7a6c8/rpy2-3.6.4.tar.gz", hash = "sha256:a24e8dda5c5ff8cbd2b8ebd1ccf6f1a5a0a576623700cf91e2cce98d41a79fd3", size = 53247 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/93/d49eccd6662ff5cec439f9de716e6520c990cec031fcdd8d08e7fd530681/rpy2-3.6.4-py3-none-any.whl", hash = "sha256:edf437d6637b89311f860fb3e44144ea5eff286a65c48645805833baff090621", size = 9895 },
+]
+
+[[package]]
+name = "rpy2-rinterface"
+version = "3.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
+    { name = "packaging", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/2a/6ced3b62a9cbfd1f3c24f7005f6eca492d906a4b6a6d56d097a116f14539/rpy2_rinterface-3.6.3.tar.gz", hash = "sha256:477bc2f51d007ad1b8567c5d4ba1af0f59951686ee7f10576a06d0834de5776f", size = 79406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/37/693585c2f245cd2f55e13e76474cf91387bcf87aa7aab0fed34ff6a38a98/rpy2_rinterface-3.6.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:164a0bce6ce01569a5c6088e51c1c4f8731929da6ace4a9e196eb68cddde234a", size = 173186 },
+    { url = "https://files.pythonhosted.org/packages/c3/ce/98a476a958489d26a1ea77e0191fb05936197295fab7eed20f5b78a92a0c/rpy2_rinterface-3.6.3-cp310-cp310-win_amd64.whl", hash = "sha256:d8c9b03ea5e70b4ee57393dd470646e9219a7a0a3a3c62a5ba030b8a2639e75a", size = 174111 },
+    { url = "https://files.pythonhosted.org/packages/63/19/da710ec205e826767894c2a968142a8cd5e97c607bdc51fcc65cb847b869/rpy2_rinterface-3.6.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:11af333c766d9220fb88c00b7419e0443e3a8fe9b272cbc079cb158db303570d", size = 173189 },
+    { url = "https://files.pythonhosted.org/packages/2c/98/3655c7a498dbbc41081f9c5cf41c63f6849a4591d01a357a1cde236a231d/rpy2_rinterface-3.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:658b4864901d1cede7ba4074718a585491107a0d2d56a322c2a6feb52525287f", size = 174111 },
+    { url = "https://files.pythonhosted.org/packages/cb/69/a24661f9ebdcd1d20ab7dd30a7d360437f19eb2446cbdb1bb3e651a9ff8d/rpy2_rinterface-3.6.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:830c6a636d1ad42abcd8f8ba096975d42bfcf05b396dfaf4ff3c9e59ae182881", size = 173483 },
+    { url = "https://files.pythonhosted.org/packages/d8/d4/d06dea263670ba7938bd01c00de2ace3da4e9730b8a0becf08c7c8574e69/rpy2_rinterface-3.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:c79572bb205f4eb19d51b81395f0370f7ea793e74352da1ed63b25d9f9970fd8", size = 174533 },
+    { url = "https://files.pythonhosted.org/packages/72/ee/0c5774b75862b148ae9e0f97feed2b6abf899c652f0df8cc5556c149f6dc/rpy2_rinterface-3.6.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62c6bc4a4566d4cd227a377c95c2a2be0e30bfb7b9ed3d5bea58e1c4cdfdf024", size = 173477 },
+    { url = "https://files.pythonhosted.org/packages/d8/0e/f0463f33815875e3b7da58c6f13df1d4e416d4abe57aa9261a31910ef6ca/rpy2_rinterface-3.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:b6eb511a07e30d7253b6fc401c14dbc9cc94efd70abdaa421f5101654c012d68", size = 174531 },
+]
+
+[[package]]
+name = "rpy2-robjects"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
     { name = "jinja2" },
-    { name = "packaging", marker = "sys_platform == 'win32'" },
+    { name = "packaging", marker = "platform_system == 'Windows'" },
+    { name = "rpy2-rinterface" },
     { name = "tzlocal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/85/f3bf48052106fd93e74bea512a43d3de48617953cba7e6dd40e8626f27f5/rpy2-3.5.17.tar.gz", hash = "sha256:dbff08c30f3d79161922623858a5b3b68a3fba8ee1747d6af41bc4ba68f3d582", size = 220963 }
+sdist = { url = "https://files.pythonhosted.org/packages/01/58/107252dab2d342eb77bd84d672abc6ecb57428758e251cfccf841c4b6a69/rpy2_robjects-3.6.3.tar.gz", hash = "sha256:731aa1a4905c4b25c0564d72cbfd85f9230102f989e7a22515885e91d4df3d40", size = 105849 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/af/a794c935ddd3dd8b47a8931e0c8cee1b756ff983db288284786ad29a8bf8/rpy2_robjects-3.6.3-py3-none-any.whl", hash = "sha256:de58c7126dbcd66c4692e7aef91d3cc57a96134828d37a268669f78ee64b974d", size = 125862 },
+]
 
 [[package]]
 name = "ruff"
@@ -1205,7 +1240,7 @@ name = "tzlocal"
 version = "5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/cc/11360404b20a6340b9b4ed39a3338c4af47bc63f87f6cea94dbcbde07029/tzlocal-5.3.tar.gz", hash = "sha256:2fafbfc07e9d8b49ade18f898d6bcd37ae88ce3ad6486842a2e4f03af68323d2", size = 30480 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -230,7 +230,7 @@ wheels = [
 
 [[package]]
 name = "fast-fmm-rpy2"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
The object created by fui() is of the type r2py.rlike.container.NamedList, which does not support the operator ["key"]. This could be used with the old data type OrdDict, which is now deprecated. Instead one has to use NamedList.getbyname("").

-changed all uses of the old dictionary type to NamedList type (e.g. fuiobj["betaHat"]->fuiobj.getbyname("betaHat"))

This fixes, e.g., the plot_fui() part of the Tutorials of photometry_FLMM.  